### PR TITLE
Make calibration button functional and user-friendly

### DIFF
--- a/app.js
+++ b/app.js
@@ -2449,7 +2449,7 @@ class FLLRoboticsApp extends EventEmitter {
 
     async startCalibration() {
         if (!this.bleController.connected && !this.isDeveloperMode) {
-            this.toastManager.show('Connect to hub or enable simulation mode to calibrate', 'warning');
+            this.toastManager.show('Robot not connected, connect to use this feature', 'warning');
             return;
         }
 


### PR DESCRIPTION
Make the start calibration button display a "robot not connected" message when not connected to a robot.

---

[Open in Web](https://cursor.com/agents?id=bc-e42f5f2d-c92d-4793-9a2f-0438a4d457dc) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-e42f5f2d-c92d-4793-9a2f-0438a4d457dc) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)