### PR TITLE
Fix app stuck on initialization

### DIFF
--- a/app.js
+++ b/app.js
@@ -1397,10 +1397,22 @@ class FLLRoboticsApp extends EventEmitter {
                     setTimeout(() => {
                         loadingScreen.style.display = 'none';
                         if (appContainer) appContainer.style.display = 'flex';
+                        
+                        // Now that the app is visible, set up the robot simulator if it wasn't initialized
+                        if (!this.robotSimulator) {
+                            setTimeout(() => this.setupRobotSimulator(), 100);
+                        }
+                        
                         resolve();
                     }, 500);
                 } else {
                     if (appContainer) appContainer.style.display = 'flex';
+                    
+                    // Now that the app is visible, set up the robot simulator if it wasn't initialized
+                    if (!this.robotSimulator) {
+                        setTimeout(() => this.setupRobotSimulator(), 100);
+                    }
+                    
                     resolve();
                 }
             }, 2000); // Show loading for at least 2 seconds
@@ -1524,10 +1536,12 @@ class FLLRoboticsApp extends EventEmitter {
         if (canvas) {
             const rect = canvas.getBoundingClientRect();
             
-            // Ensure canvas has proper initial dimensions
+            // Check if the canvas is visible and has dimensions
+            // If not, we'll set it up later when the app container becomes visible
             if (rect.width === 0 || rect.height === 0) {
-                // Wait for the element to have dimensions
-                setTimeout(() => this.setupRobotSimulator(), 100);
+                console.log('Canvas not ready yet, will initialize simulator later');
+                // Don't set up infinite retry loop during initialization
+                // The simulator will be set up when the app becomes visible
                 return;
             }
             


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes app stuck on loading screen by preventing infinite loop in robot simulator setup.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `setupRobotSimulator` method had a recursive `setTimeout` call that would infinitely retry if the canvas had zero dimensions. This occurred because the `appContainer` (which contains the canvas) was hidden (`display: none`) during initialization. This PR removes the infinite retry and instead ensures `setupRobotSimulator` is called only after the `appContainer` becomes visible, allowing the app to fully initialize.

---
<a href="https://cursor.com/background-agent?bcId=bc-2a9a4275-7e36-493a-bda1-f9fbfb644799">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2a9a4275-7e36-493a-bda1-f9fbfb644799">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>