### PR TITLE
Fix saved runs initialization error

### DIFF
--- a/app.js
+++ b/app.js
@@ -1454,6 +1454,25 @@ class FLLRoboticsApp extends EventEmitter {
         }
     }
 
+    // Helper function to get saved runs as array (handles both Map and array formats)
+    getSavedRunsArray() {
+        const savedRunsData = localStorage.getItem(STORAGE_KEYS.SAVED_RUNS);
+        let savedRuns = [];
+        
+        if (savedRunsData) {
+            const parsedData = JSON.parse(savedRunsData);
+            // Handle both Map-like object structure and array structure
+            if (Array.isArray(parsedData)) {
+                savedRuns = parsedData;
+            } else if (typeof parsedData === 'object' && parsedData !== null) {
+                // Convert object entries to array format
+                savedRuns = Object.values(parsedData);
+            }
+        }
+        
+        return savedRuns;
+    }
+
     saveUserData() {
         try {
             localStorage.setItem(STORAGE_KEYS.CONFIG, JSON.stringify(this.config));
@@ -1952,7 +1971,7 @@ class FLLRoboticsApp extends EventEmitter {
         const runsList = document.getElementById('savedRunsList');
         if (!runsList) return;
 
-        const savedRuns = JSON.parse(localStorage.getItem(STORAGE_KEYS.SAVED_RUNS) || '[]');
+        const savedRuns = this.getSavedRunsArray();
         
         runsList.innerHTML = '<option value="">Select a saved run...</option>';
         
@@ -2189,7 +2208,7 @@ class FLLRoboticsApp extends EventEmitter {
         };
 
         // Save to localStorage
-        const savedRuns = JSON.parse(localStorage.getItem(STORAGE_KEYS.SAVED_RUNS) || '[]');
+        const savedRuns = this.getSavedRunsArray();
         savedRuns.push(run);
         localStorage.setItem(STORAGE_KEYS.SAVED_RUNS, JSON.stringify(savedRuns));
 
@@ -2441,7 +2460,7 @@ class FLLRoboticsApp extends EventEmitter {
 
     generateHubCode() {
         // Get saved runs for competition code generation
-        const savedRuns = JSON.parse(localStorage.getItem(STORAGE_KEYS.SAVED_RUNS) || '[]');
+        const savedRuns = this.getSavedRunsArray();
         
         // Get calibration data
         const calibrationData = this.calibrationData || JSON.parse(localStorage.getItem(STORAGE_KEYS.CALIBRATION_DATA) || 'null');
@@ -2942,7 +2961,7 @@ while True:
             return;
         }
 
-        const savedRuns = JSON.parse(localStorage.getItem(STORAGE_KEYS.SAVED_RUNS) || '[]');
+        const savedRuns = this.getSavedRunsArray();
         const selectedRun = savedRuns.find(run => run.id === runsList.value);
         
         if (!selectedRun) {
@@ -2977,7 +2996,7 @@ while True:
             return;
         }
 
-        const savedRuns = JSON.parse(localStorage.getItem(STORAGE_KEYS.SAVED_RUNS) || '[]');
+        const savedRuns = this.getSavedRunsArray();
         const selectedRun = savedRuns.find(run => run.id === runsList.value);
         
         if (!selectedRun) {
@@ -3020,7 +3039,7 @@ while True:
                         throw new Error('Invalid run file format');
                     }
 
-                    const savedRuns = JSON.parse(localStorage.getItem(STORAGE_KEYS.SAVED_RUNS) || '[]');
+                    const savedRuns = this.getSavedRunsArray();
                     
                     // Create a new run with imported data
                     const newRun = {
@@ -3074,7 +3093,7 @@ while True:
             return;
         }
 
-        const savedRuns = JSON.parse(localStorage.getItem(STORAGE_KEYS.SAVED_RUNS) || '[]');
+        const savedRuns = this.getSavedRunsArray();
         const selectedRun = savedRuns.find(run => run.id === runsList.value);
         
         if (!selectedRun) {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes "savedRuns.forEach is not a function" by standardizing `savedRuns` retrieval to always return an array, resolving data structure inconsistencies.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The application stored `savedRuns` in localStorage in two different formats: as an object (converted from a Map) and as an array. Functions expecting an array would fail when an object was retrieved, as objects lack the `forEach` method. This PR introduces a helper `getSavedRunsArray()` to intelligently convert stored data into an array format, ensuring `forEach` is always available and providing backward compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-0ee23a5a-f414-4316-a679-2b97f83a9b49">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0ee23a5a-f414-4316-a679-2b97f83a9b49">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>