### PR TITLE
Find text for pybricks hub connection

### DIFF
--- a/app.js
+++ b/app.js
@@ -2539,7 +2539,7 @@ class FLLRoboticsApp extends EventEmitter {
                 if (this.config.simulateConnected) {
                     connectBtn.innerHTML = '<i class="fas fa-robot" aria-hidden="true"></i> Start Simulation';
                 } else {
-                    connectBtn.innerHTML = '<i class="fas fa-bluetooth" aria-hidden="true"></i> Connect to Pybricks Hub';
+                    connectBtn.innerHTML = 'Connect to Pybricks Hub';
                 }
                 connectBtn.disabled = false;
                 hubStatus.className = 'status-indicator disconnected';

--- a/index.html
+++ b/index.html
@@ -155,7 +155,6 @@
                     </div>
                     <div class="section-content">
                         <button id="connectBtn" class="btn btn-primary" aria-describedby="hubStatus">
-                            <i class="fas fa-bluetooth" aria-hidden="true"></i>
                             Connect to Pybricks Hub
                         </button>
                         <button id="connectXboxBtn" class="btn btn-secondary" style="margin-top: 10px;">


### PR DESCRIPTION
Remove the broken Bluetooth icon from the "Connect to Pybricks Hub" button.

---
<a href="https://cursor.com/background-agent?bcId=bc-66e6bbd8-cc5a-4925-bc7c-7fa0c5df9b52">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-66e6bbd8-cc5a-4925-bc7c-7fa0c5df9b52">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>