### PR TITLE
Fix xbox controller spin bug on reconnect

### DIFF
--- a/app.js
+++ b/app.js
@@ -2109,6 +2109,17 @@ class FLLRoboticsApp extends EventEmitter {
             title.textContent = 'Searching for Xbox Controller';
             statusText.textContent = 'Press any button on your Xbox controller to connect...';
             
+            // Reset the 3D model auto-rotation
+            const modelViewer = modal.querySelector('#xboxController3D');
+            if (modelViewer) {
+                // Remove and re-add the auto-rotate attribute to restart the animation
+                modelViewer.removeAttribute('auto-rotate');
+                // Use setTimeout to ensure the attribute removal is processed before re-adding
+                setTimeout(() => {
+                    modelViewer.setAttribute('auto-rotate', '');
+                }, 10);
+            }
+            
             // Set a timeout to close the modal if no controller connects
             this.xboxConnectionTimeout = setTimeout(() => {
                 if (!this.xboxController.isConnected()) {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Restart Xbox controller 3D model auto-rotation when the connect modal is shown to ensure consistent animation.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `model-viewer` component automatically disables `auto-rotate` after user interaction. When the modal is closed and reopened, it remembers this state and does not restart the rotation. This change forces the `auto-rotate` to re-engage every time the modal is displayed.

---
<a href="https://cursor.com/background-agent?bcId=bc-984c3338-32c0-4600-84bd-5457c2bfd4d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-984c3338-32c0-4600-84bd-5457c2bfd4d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>