### PR TITLE
Hide simulator and use default map

### DIFF
--- a/index.html
+++ b/index.html
@@ -335,10 +335,6 @@
                                 </div>
                             </div>
                             <div class="button-group">
-                                <button id="uploadMapBtn" class="btn btn-primary">
-                                    <i class="fas fa-upload" aria-hidden="true"></i>
-                                    Upload Map
-                                </button>
                                 <button id="resetSimBtn" class="btn btn-success">
                                     <i class="fas fa-refresh" aria-hidden="true"></i>
                                     Reset Position


### PR DESCRIPTION
Hide the robot simulator when not in seamless mode, set the default map to `Map.jpg`, and remove the map upload option.

---
<a href="https://cursor.com/background-agent?bcId=bc-4901e557-d3de-4d88-9817-48d1ac1b7960">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4901e557-d3de-4d88-9817-48d1ac1b7960">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

