### PR TITLE
Remove simulation mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -218,11 +218,6 @@
                             <i class="fas fa-gamepad" aria-hidden="true"></i>
                             Connect Xbox Controller
                         </button>
-                        <div class="checkbox-container">
-                            <input type="checkbox" id="developerMode" class="checkbox" aria-describedby="simModeDesc">
-                            <label for="developerMode">Simulation Mode</label>
-                        </div>
-                        <small id="simModeDesc" class="help-text">Enable to test without physical robot</small>
                         <div id="hubStatus" class="status-indicator disconnected" role="status" aria-live="polite">
                             <div class="status-dot" aria-hidden="true"></div>
                             <span>Hub Disconnected</span>


### PR DESCRIPTION
Remove the 'Simulation Mode' toggle from the main UI below the connect button.

---
<a href="https://cursor.com/background-agent?bcId=bc-d78e2899-740a-4ac2-881a-1b8c3144b2ab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d78e2899-740a-4ac2-881a-1b8c3144b2ab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

