### PR TITLE
Enable simulate toggle on no bluetooth

### DIFF
--- a/app.js
+++ b/app.js
@@ -1675,6 +1675,14 @@ class FLLRoboticsApp extends EventEmitter {
             this.clearCorruptedData();
         }
         
+        // Auto-enable simulation if Bluetooth is unavailable
+        if (!navigator.bluetooth && !this.config.simulateConnected) {
+            this.config.simulateConnected = true;
+            try { localStorage.setItem(STORAGE_KEYS.CONFIG, JSON.stringify(this.config)); } catch (e) {}
+            this.logger.log('Bluetooth not supported; enabling simulated connection automatically.', 'warning');
+            this.toastManager.show('Bluetooth not supported in this browser. Simulated connection has been enabled automatically.', 'warning', 8000);
+        }
+        
         // Apply simulation state after loading config
         console.log('Loading user data complete, applying simulation state...');
         this.applySimulationState();
@@ -2603,7 +2611,7 @@ class FLLRoboticsApp extends EventEmitter {
         if (!connectBtn || !hubStatus) return;
 
         // If Bluetooth unavailable, keep app interactive but disable connect button with debug message
-        if (!navigator.bluetooth || !window.isSecureContext) {
+        if ((!navigator.bluetooth || !window.isSecureContext) && !this.bleController.isSimulatingConnection && !this.config.simulateConnected) {
             connectBtn.innerHTML = '<i class="fas fa-exclamation-triangle" aria-hidden="true"></i> Bluetooth Unavailable';
             connectBtn.disabled = true;
             hubStatus.className = 'status-indicator error';


### PR DESCRIPTION
Automatically enable "Simulate connected" and notify the user when Bluetooth is unsupported, ensuring the app remains usable.

---
<a href="https://cursor.com/background-agent?bcId=bc-e8cc16ef-c3bd-42c6-acf1-fac04efcf380">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e8cc16ef-c3bd-42c6-acf1-fac04efcf380">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

