### PR TITLE
Analyze robot movement code for issues

### DIFF
--- a/app.js
+++ b/app.js
@@ -951,27 +951,8 @@ class RobotSimulator extends EventEmitter {
     }
 
     updateCommand(command) {
-        // Apply calibration factors if available
+        // Pass commands directly to simulator targets without calibration
         let calibratedCommand = { ...command };
-        
-        if (this.calibrationFactors) {
-            if (command.type === 'drive') {
-                // Apply speed and turn calibration
-                calibratedCommand.speed = (command.speed || 0) * this.calibrationFactors.speedMultiplier;
-                calibratedCommand.turn_rate = (command.turn_rate || 0) * this.calibrationFactors.turnMultiplier;
-                
-                // Apply drift compensation for straight movement
-                if (command.turn_rate === 0 && command.speed !== 0) {
-                    // Add slight turn to compensate for drift
-                    const driftCompensation = this.calibrationFactors.driftCompensation;
-                    if (driftCompensation && (driftCompensation.x !== 0 || driftCompensation.y !== 0)) {
-                        // Calculate drift compensation angle
-                        const driftAngle = Math.atan2(driftCompensation.y, driftCompensation.x) * 180 / Math.PI;
-                        calibratedCommand.turn_rate = -driftAngle * 0.1; // Small compensation
-                    }
-                }
-            }
-        }
         
         // Update simulator targets based on command type
         if (calibratedCommand.type === 'drive') {


### PR DESCRIPTION
Remove simulator-side drift and calibration compensation because GyroDriveBase provides built-in drift compensation, and the calibration system is no longer used.

---
<a href="https://cursor.com/background-agent?bcId=bc-9efd6907-daa0-4257-a819-1526faac2cf0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9efd6907-daa0-4257-a819-1526faac2cf0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

