### PR TITLE
Fix button hover flicker on edge

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -90,11 +90,11 @@ body {
     background: rgba(255, 255, 255, 0.3);
     transform: translate(-50%, -50%);
     transition: width 0.6s, height 0.6s;
+    pointer-events: none;
 }
 
 .window-btn:hover {
     background: rgba(255, 255, 255, 0.2);
-    transform: scale(1.05);
     box-shadow: 0 4px 12px rgba(255, 255, 255, 0.1);
 }
 
@@ -104,7 +104,7 @@ body {
 }
 
 .window-btn:active {
-    transform: scale(0.95);
+    transform: none;
 }
 
 .close-btn:hover {
@@ -202,7 +202,6 @@ body {
 }
 
 .btn:hover {
-    transform: translateY(-2px);
     box-shadow: 0 8px 20px rgba(0, 0, 0, 0.3);
 }
 
@@ -220,6 +219,7 @@ body {
     height: 100%;
     background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.2), transparent);
     transition: left 0.5s;
+    pointer-events: none;
 }
 
 .btn:hover::before {
@@ -235,7 +235,6 @@ body {
 .btn-primary:hover {
     background: linear-gradient(135deg, #0098e6 0%, #0068bd 100%);
     box-shadow: 0 6px 20px rgba(0, 168, 255, 0.4);
-    transform: translateY(-2px);
 }
 
 .btn-success {
@@ -247,7 +246,6 @@ body {
 .btn-success:hover {
     background: linear-gradient(135deg, #218838 0%, #155724 100%);
     box-shadow: 0 6px 20px rgba(40, 167, 69, 0.4);
-    transform: translateY(-2px);
 }
 
 .btn-danger {
@@ -259,7 +257,6 @@ body {
 .btn-danger:hover {
     background: linear-gradient(135deg, #c82333 0%, #a71e2a 100%);
     box-shadow: 0 6px 20px rgba(220, 53, 69, 0.4);
-    transform: translateY(-2px);
 }
 
 .btn-warning {
@@ -271,7 +268,6 @@ body {
 .btn-warning:hover {
     background: linear-gradient(135deg, #e0a800 0%, #d39e00 100%);
     box-shadow: 0 6px 20px rgba(255, 193, 7, 0.4);
-    transform: translateY(-2px);
 }
 
 .btn-secondary {
@@ -283,7 +279,6 @@ body {
 .btn-secondary:hover {
     background: linear-gradient(135deg, #5a6268 0%, #495057 100%);
     box-shadow: 0 6px 20px rgba(108, 117, 125, 0.4);
-    transform: translateY(-2px);
 }
 
 .btn:disabled {
@@ -611,7 +606,6 @@ kbd:hover {
     background: linear-gradient(135deg, #00a8ff 0%, #0078d4 100%);
     border-color: rgba(0, 168, 255, 0.5);
     box-shadow: 0 6px 15px rgba(0, 168, 255, 0.3);
-    transform: translateY(-2px);
 }
 
 .key-item span {
@@ -873,7 +867,6 @@ kbd:hover {
 
 .btn-icon:hover {
     background: rgba(0, 168, 255, 0.2);
-    transform: scale(1.05);
 }
 
 /* Emergency Stop Button */
@@ -888,7 +881,6 @@ kbd:hover {
 .btn-emergency:hover {
     background: linear-gradient(135deg, #ff3742 0%, #c82333 100%) !important;
     box-shadow: 0 6px 20px rgba(255, 71, 87, 0.6);
-    transform: translateY(-2px) scale(1.02);
 }
 
 /* Help Text */


### PR DESCRIPTION
Remove CSS transforms on hover and add `pointer-events: none` to pseudo-elements to prevent button hover flickering.

Hover transforms (like `scale` or `translateY`) cause the button's effective hitbox to shift or resize, leading to rapid `mouseover`/`mouseout` events when the cursor is precisely on the edge. Pseudo-elements without `pointer-events: none` can also interfere with hover detection.

---
<a href="https://cursor.com/background-agent?bcId=bc-b8694fcb-3231-4d2a-8021-325d309b708b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b8694fcb-3231-4d2a-8021-325d309b708b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

