### PR TITLE
Remove simulator window borders

### DIFF
--- a/app.js
+++ b/app.js
@@ -1380,6 +1380,24 @@ class RobotSimulator extends EventEmitter {
 
     setBackgroundMap(image) {
         this.backgroundMap = image;
+        try {
+            const imgW = image.naturalWidth || image.width || 0;
+            const imgH = image.naturalHeight || image.height || 0;
+            if (imgW > 0 && imgH > 0) {
+                const aspect = imgW / imgH;
+                // Hint layout to match the image aspect to avoid letterboxing
+                this.canvas.style.aspectRatio = aspect.toString();
+                // Remove any fixed min-heights to allow aspect to control height
+                this.canvas.style.minHeight = '';
+                this.canvas.style.height = '';
+                // Trigger a resize/update for high-DPI and internal sizing
+                if (this.updateCanvasSize) {
+                    this.updateCanvasSize();
+                }
+            }
+        } catch (e) {
+            // no-op
+        }
     }
 
     setPose(x, y, angle = 0, options = { clearTrail: true, resetMotion: true }) {

--- a/styles.css
+++ b/styles.css
@@ -447,8 +447,6 @@ body {
 
 #robotSimulator {
     width: 100%;
-    height: min(60vh, 600px);
-    min-height: 400px;
     border: 1px solid rgba(0, 168, 255, 0.3);
     border-radius: 12px;
     background: linear-gradient(135deg, #0f0f0f 0%, #1a1a1a 100%);
@@ -1085,10 +1083,7 @@ kbd:hover {
         gap: 12px;
     }
     
-    #robotSimulator {
-        height: min(50vh, 500px);
-        min-height: 350px;
-    }
+    #robotSimulator {}
 }
 
 @media (max-width: 768px) {
@@ -1119,10 +1114,7 @@ kbd:hover {
         margin-bottom: 16px;
     }
     
-    #robotSimulator {
-        height: min(45vh, 450px);
-        min-height: 300px;
-    }
+    #robotSimulator {}
     
     .simulator-info .performance-stats {
         flex-direction: column;


### PR DESCRIPTION
Remove black side borders (pillarboxing) from the robot simulator by dynamically setting the canvas aspect ratio and removing fixed height constraints.

---
<a href="https://cursor.com/background-agent?bcId=bc-d7deb2f2-92d6-4ab2-ac05-92a11a5acae8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d7deb2f2-92d6-4ab2-ac05-92a11a5acae8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

