### PR TITLE
Shrink robot simulator by 75 percent

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -446,7 +446,9 @@ body {
 }
 
 #robotSimulator {
-    width: 100%;
+    width: 25%;
+    display: block;
+    margin: 0 auto;
     border: 1px solid rgba(0, 168, 255, 0.3);
     border-radius: 12px;
     background: linear-gradient(135deg, #0f0f0f 0%, #1a1a1a 100%);


### PR DESCRIPTION
Reduce the visual size of the robot simulator to 25% width and center it to make it approximately 75% smaller.

---
<a href="https://cursor.com/background-agent?bcId=bc-c2c7a143-a499-4de7-9067-cbb98bf51ae3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c2c7a143-a499-4de7-9067-cbb98bf51ae3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

