### PR TITLE
Fix button hitbox during hover animation

### DIFF
--- a/animations.css
+++ b/animations.css
@@ -346,10 +346,21 @@
 
 /* Hover Lift */
 .hover-lift {
-    transition: transform var(--anim-duration-fast) var(--anim-easing-default);
+    position: relative;
 }
 
-.hover-lift:hover {
+/* Inner wrapper to move visually while outer hitbox stays static */
+.hover-lift .hover-lift-inner {
+    display: inline-flex;
+    align-items: inherit;
+    justify-content: inherit;
+    width: 100%;
+    height: 100%;
+    transition: transform var(--anim-duration-fast) var(--anim-easing-default);
+    will-change: transform;
+}
+
+.hover-lift:hover .hover-lift-inner {
     transform: translateY(-4px);
 }
 

--- a/offline.html
+++ b/offline.html
@@ -319,14 +319,22 @@
         `;
         document.head.appendChild(style);
         
-        // Add some interactive feedback
+        // Add some interactive feedback without changing hitbox
         document.querySelectorAll('.btn').forEach(btn => {
+            if (!btn.querySelector('.hover-lift-inner')) {
+                const inner = document.createElement('span');
+                inner.className = 'hover-lift-inner';
+                while (btn.firstChild) inner.appendChild(btn.firstChild);
+                btn.appendChild(inner);
+            }
+
+            const inner = btn.querySelector('.hover-lift-inner');
             btn.addEventListener('mouseenter', function() {
-                this.style.transform = 'translateY(-2px) scale(1.02)';
+                inner.style.transform = 'translateY(-2px) scale(1.02)';
             });
             
             btn.addEventListener('mouseleave', function() {
-                this.style.transform = 'translateY(0) scale(1)';
+                inner.style.transform = 'translateY(0) scale(1)';
             });
         });
         


### PR DESCRIPTION
Refactor button hover lift animation to apply to an inner wrapper, preventing hitbox shifts and fixing hover glitches.

Previously, the `transform: translateY` on hover would shift the button's entire element, including its clickable area. This caused a flickering effect when the mouse was near the bottom edge of the button, as the button would move away from the cursor, deactivating the hover, then move back, reactivating it. By applying the visual transform to an inner wrapper, the outer button element's hitbox remains static, resolving this UI glitch.

---
<a href="https://cursor.com/background-agent?bcId=bc-59c935b7-1a1f-4e83-8761-b81195f13ff8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-59c935b7-1a1f-4e83-8761-b81195f13ff8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

