### PR TITLE
Add reset data button to advanced tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -539,6 +539,13 @@
                             <small id="simulateConnectedHelp" class="help-text">Make app behave as if robot is connected (for testing without physical robot)</small>
                         </div>
 
+                        <div class="config-row">
+                            <button class="btn btn-danger" onclick="resetAllData()">
+                                <i class="fas fa-trash-alt" aria-hidden="true"></i> Reset Data
+                            </button>
+                            <small class="help-text">Deletes all saved runs, settings, and calibration. Irreversible.</small>
+                        </div>
+
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Add a "Reset Data" button to the Advanced tab to allow users to clear all application data and reset the app to its initial state.

This feature provides a comprehensive reset, deleting saved runs, settings, calibration, user preferences, browser caches, and service worker registrations, ensuring the app behaves as if it were a fresh installation.

---
<a href="https://cursor.com/background-agent?bcId=bc-f9e092c4-05d9-4aa0-a332-10cb790abbd7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f9e092c4-05d9-4aa0-a332-10cb790abbd7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

