### PR TITLE
Remove home menu introductory text

### DIFF
--- a/index.html
+++ b/index.html
@@ -690,7 +690,6 @@
                     <i class="fas fa-robot" aria-hidden="true"></i>
                     <span>CodLess™</span>
                 </div>
-                <h2 class="home-title">You can choose. controlling a robot has never been simpler.</h2>
                 <div class="models-row">
                     <div class="model-card" id="keyboardCard">
                         <model-viewer 


### PR DESCRIPTION
Remove the tagline "You can choose. controlling a robot has never been simpler." from the home menu.

---
<a href="https://cursor.com/background-agent?bcId=bc-9b7c231d-dede-4754-a059-91e3f0fd4b8a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9b7c231d-dede-4754-a059-91e3f0fd4b8a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

