### PR TITLE
Adjust home menu visuals and interactions

### DIFF
--- a/index.html
+++ b/index.html
@@ -758,9 +758,8 @@
             }
 
             function setupHover(card, model){
-                if(!card || !model) return;
-                card.addEventListener('mouseenter', ()=> setSpin(model, 6));
-                card.addEventListener('mouseleave', ()=> setSpin(model, 15));
+                // Hover interactions disabled
+                return;
             }
 
             setupHover(xboxCard, xbox);

--- a/styles.css
+++ b/styles.css
@@ -2553,6 +2553,7 @@ body::-webkit-scrollbar-track {
     padding: 28px;
     box-shadow: 0 30px 80px rgba(0,0,0,0.50), inset 0 1px 0 rgba(255,255,255,0.06);
     backdrop-filter: blur(14px);
+    text-align: center;
 }
 .brand-badge {
     display: inline-flex;
@@ -2564,7 +2565,7 @@ body::-webkit-scrollbar-track {
     border: 1px solid rgba(0,168,255,0.35);
     color: #dff3ff;
     box-shadow: 0 6px 20px rgba(0,168,255,0.18);
-    margin-bottom: 18px;
+    margin: 0 auto 18px;
 }
 .brand-badge i { color: #00a8ff; }
 .brand-badge span { font-weight: 600; letter-spacing: 0.2px; }
@@ -2574,7 +2575,9 @@ body::-webkit-scrollbar-track {
     font-weight: 700;
     margin: 8px 0 22px 0;
     background: linear-gradient(180deg, #ffffff, #b9dfff);
-    -webkit-background-clip: text background-clip: text; -webkit-text-fill-color: transparent;
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
     text-shadow: 0 6px 30px rgba(0,168,255,0.12);
 }
 .models-row {
@@ -2592,9 +2595,9 @@ body::-webkit-scrollbar-track {
     transition: transform 0.6s cubic-bezier(0.2, 0.8, 0.2, 1), box-shadow 0.4s ease, border-color 0.3s ease;
 }
 .model-card:hover {
-    transform: translateY(-4px);
-    border-color: rgba(0,168,255,0.35);
-    box-shadow: 0 30px 80px rgba(0,168,255,0.12);
+    transform: none;
+    border-color: rgba(255,255,255,0.08);
+    box-shadow: 0 18px 50px rgba(0,0,0,0.45), inset 0 1px 0 rgba(255,255,255,0.05);
 }
 .model-label {
     position: absolute;


### PR DESCRIPTION
Disable hover effects on home menu 3D models and center the CodLess logo and app button.

A CSS syntax error in `.home-title` was also corrected during this change.

---
<a href="https://cursor.com/background-agent?bcId=bc-51da7b7f-8b59-4b17-8a22-da69385656ee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-51da7b7f-8b59-4b17-8a22-da69385656ee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

