### PR TITLE
Filter bluetooth devices for pybricks hubs

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -434,12 +434,15 @@ class BLEController extends EventEmitter {
             }
             this.emit('connecting');
             this.device = await navigator.bluetooth.requestDevice({
-                // Use acceptAllDevices with optionalServices to allow hubs with different names
-                acceptAllDevices: true,
+                // Show only Pybricks hubs
+                filters: [
+                    { services: [APP_CONFIG.BLUETOOTH_SERVICE_UUID] },
+                    { namePrefix: APP_CONFIG.HUB_NAME_PREFIX }
+                ],
                 optionalServices: [
-                    APP_CONFIG.BLUETOOTH_SERVICE_UUID, // Pybricks service
-                    APP_CONFIG.BLUETOOTH_CHARACTERISTIC_UUID,
-                    '6e400001-b5a3-f393-e0a9-e50e24dcca9e' // Nordic UART service (some hubs expose this during DFU)
+                    APP_CONFIG.BLUETOOTH_SERVICE_UUID,
+                    'battery_service',
+                    'device_information'
                 ]
             });
             this.device.addEventListener('gattserverdisconnected', () => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -507,12 +507,15 @@ class BLEController extends EventEmitter {
             this.emit('connecting');
             
             this.device = await navigator.bluetooth.requestDevice({
-                // Use acceptAllDevices with optionalServices to allow hubs with different names
-                acceptAllDevices: true,
+                // Show only Pybricks hubs
+                filters: [
+                    { services: [APP_CONFIG.BLUETOOTH_SERVICE_UUID] },
+                    { namePrefix: APP_CONFIG.HUB_NAME_PREFIX }
+                ],
                 optionalServices: [
-                    APP_CONFIG.BLUETOOTH_SERVICE_UUID, // Pybricks service
-                    APP_CONFIG.BLUETOOTH_CHARACTERISTIC_UUID,
-                    '6e400001-b5a3-f393-e0a9-e50e24dcca9e' // Nordic UART service (some hubs expose this during DFU)
+                    APP_CONFIG.BLUETOOTH_SERVICE_UUID,
+                    'battery_service',
+                    'device_information'
                 ]
             });
 


### PR DESCRIPTION
Filter Bluetooth device discovery to show only Pybricks hubs, improving the connection experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-dce9a9d5-6e8c-4fba-9939-f6e03b4f3926"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dce9a9d5-6e8c-4fba-9939-f6e03b4f3926"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

