### PR TITLE
Enable console text copying

### DIFF
--- a/docs/assets/css/styles.css
+++ b/docs/assets/css/styles.css
@@ -561,6 +561,17 @@ body {
     border-radius: 3px;
 }
 
+/* Allow selecting and copying text inside the console/status area */
+#statusDisplay,
+.status-display,
+.status-display * {
+    user-select: text;
+    -webkit-user-select: text;
+    -moz-user-select: text;
+    -ms-user-select: text;
+    cursor: text;
+}
+
 .controls-grid {
     display: grid;
     grid-template-columns: 1fr 1fr;


### PR DESCRIPTION
Enable text selection in the console/status display to allow users to copy log messages.

---
<a href="https://cursor.com/background-agent?bcId=bc-6d65e499-72f5-4c4d-9e53-ddb889e5eb08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6d65e499-72f5-4c4d-9e53-ddb889e5eb08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

